### PR TITLE
Add etcd-backed durable registry with multi-replica support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,22 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install build dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          packages=(protobuf-compiler)
+
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            packages+=(gcc-aarch64-linux-gnu)
+          fi
+
+          sudo apt-get install -y "${packages[@]}"
+
+      - name: Install build dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install protobuf
 
       - name: Build release binary
         run: cargo build --locked --release --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +310,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcd-client"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed900ba953ca6bf1fadb75e0c6b73d8463b9e2bb6bdb7b4573e8e7295852fbe"
+dependencies = [
+ "http",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tower",
+ "tower-service",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "figment"
 version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +373,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -528,6 +570,15 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -541,6 +592,12 @@ dependencies = [
  "byteorder",
  "num-traits",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -630,6 +687,19 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -794,6 +864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +901,12 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -905,6 +990,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +1014,7 @@ dependencies = [
  "fred",
  "nscale-consul",
  "nscale-core",
+ "nscale-etcd",
  "nscale-nomad",
  "nscale-proxy",
  "nscale-scaler",
@@ -960,10 +1052,26 @@ version = "2.1.0"
 dependencies = [
  "async-trait",
  "figment",
+ "futures-core",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nscale-etcd"
+version = "2.1.0"
+dependencies = [
+ "async-trait",
+ "etcd-client",
+ "futures-core",
+ "futures-util",
+ "nscale-core",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]
@@ -1147,6 +1255,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1322,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,6 +1354,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,7 +1439,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -1274,7 +1476,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1465,6 +1667,19 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -1766,6 +1981,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,6 +2152,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.3",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+ "tempfile",
+ "tonic-build",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2370,12 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/nscale-nomad",
     "crates/nscale-consul",
     "crates/nscale-store",
+    "crates/nscale-etcd",
     "crates/nscale-proxy",
     "crates/nscale-waker",
     "crates/nscale-scaler",
@@ -25,6 +26,7 @@ nscale-core = { path = "crates/nscale-core" }
 nscale-nomad = { path = "crates/nscale-nomad" }
 nscale-consul = { path = "crates/nscale-consul" }
 nscale-store = { path = "crates/nscale-store" }
+nscale-etcd = { path = "crates/nscale-etcd" }
 nscale-proxy = { path = "crates/nscale-proxy" }
 nscale-waker = { path = "crates/nscale-waker" }
 nscale-scaler = { path = "crates/nscale-scaler" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM rust:1.94-bookworm AS builder
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /build
 COPY . .
 RUN cargo build --release

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 ARG TARGETPLATFORM
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl protobuf-compiler \
+  && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 ARG TARGETPLATFORM
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && apt-get install -y --no-install-recommends ca-certificates curl protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ graph LR
     nscale -->|proxy| Backend["Nomad job<br/>(healthy allocation)"]
     nscale -->|scale up| Nomad
     nscale -->|health poll| Consul
-    nscale -->|activity + registry| Redis
+    nscale -->|activity + cache| Redis
+    nscale -->|durable registry| Etcd[(etcd)]
 
     Nomad -->|registers service| Consul
     Consul -->|service discovery| Traefik
@@ -122,7 +123,8 @@ flowchart TD
 | `nscale-core` | Shared types, config (Figment), traits, `InFlightTracker` |
 | `nscale-nomad` | Nomad API client — scale up/down, event stream |
 | `nscale-consul` | Consul catalog — health checks, service discovery |
-| `nscale-store` | Redis activity store (sorted set) and job registry |
+| `nscale-store` | Redis activity store (sorted set) and registry cache |
+| `nscale-etcd` | Durable job-registration store used as the registry source of truth |
 | `nscale-proxy` | Reverse proxy with in-flight tracking and heartbeat |
 | `nscale-waker` | Wake coordinator — request coalescing, state machine |
 | `nscale-scaler` | Scale-down controller with traffic probe + in-flight guard |
@@ -135,6 +137,7 @@ flowchart TD
 - **Heartbeat activity** — Long-running requests refresh activity every `idle_timeout / 3`, surviving any idle window
 - **Reverse proxy** — All requests (cold and warm path) route through nscale for full visibility
 - **Idle detection** — Services with no recent activity are scaled to zero via Redis sorted set
+- **Durable registry** — Job registrations can be stored in etcd and cached in Redis for resilient multi-replica recovery
 - **Traffic probe** — Scrapes Traefik Prometheus metrics as a secondary guard against scaling down active services
 - **Retry with cache invalidation** — On upstream failure, invalidates stale endpoints and retries the full wake cycle
 - **Nomad event stream** — Reacts to allocation lifecycle events for instant state transitions
@@ -142,8 +145,9 @@ flowchart TD
 - **Bounded concurrency** — Configurable limit on simultaneous Nomad scale operations
 
 Additional operator docs live in [`docs/`](./docs/), starting with the
-[`performance-configuration.md`](./docs/performance-configuration.md) guide and the
-[`job-submission.md`](./docs/job-submission.md) guide for the new admin submission flow.
+[`performance-configuration.md`](./docs/performance-configuration.md) guide,
+[`job-submission.md`](./docs/job-submission.md) for the admin submission flow,
+and [`durable-registry.md`](./docs/durable-registry.md) for etcd-backed registry mode.
 
 ## Quick Start
 
@@ -249,6 +253,10 @@ Nested keys use **double underscores** (Figment `.split("__")`).
 | `NSCALE_CONSUL__ADDR` | `http://localhost:8500` | Consul API address |
 | `NSCALE_CONSUL__TOKEN` | — | Consul ACL token (optional) |
 | `NSCALE_REDIS__URL` | `redis://localhost:6379` | Redis connection URL |
+| `NSCALE_REGISTRY__DURABLE_ENABLED` | `false` | Enable etcd-backed durable registrations and Redis read-through cache |
+| `NSCALE_REGISTRY__ETCD_ENDPOINTS` | `http://localhost:2379` | Comma-separated etcd endpoints |
+| `NSCALE_REGISTRY__ETCD_KEY_PREFIX` | `/nscale/registrations` | etcd key prefix used for registrations |
+| `NSCALE_REGISTRY__ETCD_WATCH_BACKOFF_SECS` | `5` | Backoff between durable registry reconciliation attempts |
 | `NSCALE_SCALING__IDLE_TIMEOUT_SECS` | `300` | Seconds before idle service is scaled down |
 | `NSCALE_SCALING__WAKE_TIMEOUT_SECS` | `60` | Max seconds to wait for a service to become healthy |
 | `NSCALE_SCALING__SCALE_DOWN_INTERVAL_SECS` | `30` | Scale-down sweep interval |
@@ -496,6 +504,18 @@ The main integration script now submits `jobs/echo-submit.nomad` through `/admin
 that nscale injected the Traefik service override tag in Consul, confirms lookup still works when
 `service_name` differs from `job_id`, and then exercises wake-up and automatic scale-down.
 
+### Durable registry mode
+
+```bash
+cd integration
+./test-durable.sh
+./test-durable-multi-replica.sh
+```
+
+The durable integration scripts enable etcd-backed registrations, verify Redis cache loss recovery,
+and confirm that a second nscale replica can serve requests by reading through to etcd and
+repopulating Redis.
+
 ### Multi-job management
 
 ```bash
@@ -522,6 +542,10 @@ nscale will scale it down once `idle_timeout` expires if there's no traffic.
 
 If you submit jobs outside nscale, use `/admin/registry` or `/admin/registry/sync` to add
 the same registration data manually.
+
+If durable registry mode is enabled, nscale writes registrations to etcd first and then refreshes
+the Redis cache. A Redis cache miss is then repaired by reading from etcd and writing the result
+back into Redis.
 
 ### 2. Cold-start wake
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Nested keys use **double underscores** (Figment `.split("__")`).
 | `NSCALE_REGISTRY__DURABLE_ENABLED` | `false` | Enable etcd-backed durable registrations and Redis read-through cache |
 | `NSCALE_REGISTRY__ETCD_ENDPOINTS` | `http://localhost:2379` | Comma-separated etcd endpoints |
 | `NSCALE_REGISTRY__ETCD_KEY_PREFIX` | `/nscale/registrations` | etcd key prefix used for registrations |
-| `NSCALE_REGISTRY__ETCD_WATCH_BACKOFF_SECS` | `5` | Backoff between durable registry reconciliation attempts |
+| `NSCALE_REGISTRY__ETCD_WATCH_BACKOFF_SECS` | `5` | Reserved for future watch/reconciliation backoff wiring; currently ignored |
 | `NSCALE_SCALING__IDLE_TIMEOUT_SECS` | `300` | Seconds before idle service is scaled down |
 | `NSCALE_SCALING__WAKE_TIMEOUT_SECS` | `60` | Max seconds to wait for a service to become healthy |
 | `NSCALE_SCALING__SCALE_DOWN_INTERVAL_SECS` | `30` | Scale-down sweep interval |

--- a/config/default.toml
+++ b/config/default.toml
@@ -22,5 +22,11 @@ min_scale_down_age_secs = 120
 request_timeout_secs = 30
 request_buffer_size = 1000
 
+[default.registry]
+durable_enabled = false
+etcd_endpoints = "http://localhost:2379"
+etcd_key_prefix = "/nscale/registrations"
+etcd_watch_backoff_secs = 5
+
 [default.routing]
 file_provider_service = "s2z-nscale@file"

--- a/crates/nscale-core/src/config.rs
+++ b/crates/nscale-core/src/config.rs
@@ -17,6 +17,8 @@ pub struct Config {
     pub scaling: ScalingConfig,
     pub proxy: ProxyConfig,
     #[serde(default)]
+    pub registry: RegistryConfig,
+    #[serde(default)]
     pub routing: RoutingConfig,
     #[serde(default)]
     pub traefik: Option<TraefikConfig>,
@@ -41,6 +43,18 @@ pub struct ConsulConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RedisConfig {
     pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistryConfig {
+    #[serde(default)]
+    pub durable_enabled: bool,
+    #[serde(default = "default_etcd_endpoints")]
+    pub etcd_endpoints: String,
+    #[serde(default = "default_etcd_key_prefix")]
+    pub etcd_key_prefix: String,
+    #[serde(default = "default_etcd_watch_backoff")]
+    pub etcd_watch_backoff_secs: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -104,6 +118,17 @@ impl Default for RoutingConfig {
     }
 }
 
+impl Default for RegistryConfig {
+    fn default() -> Self {
+        Self {
+            durable_enabled: false,
+            etcd_endpoints: default_etcd_endpoints(),
+            etcd_key_prefix: default_etcd_key_prefix(),
+            etcd_watch_backoff_secs: default_etcd_watch_backoff(),
+        }
+    }
+}
+
 impl ProxyConfig {
     pub fn request_timeout(&self) -> Duration {
         Duration::from_secs(self.request_timeout_secs)
@@ -130,6 +155,15 @@ fn default_request_timeout() -> u64 {
 }
 fn default_request_buffer_size() -> usize {
     1000
+}
+fn default_etcd_endpoints() -> String {
+    "http://localhost:2379".to_string()
+}
+fn default_etcd_key_prefix() -> String {
+    "/nscale/registrations".to_string()
+}
+fn default_etcd_watch_backoff() -> u64 {
+    5
 }
 fn default_file_provider_service() -> String {
     "s2z-nscale@file".to_string()
@@ -165,6 +199,7 @@ impl Default for Config {
                 request_timeout_secs: default_request_timeout(),
                 request_buffer_size: default_request_buffer_size(),
             },
+            registry: RegistryConfig::default(),
             routing: RoutingConfig {
                 file_provider_service: default_file_provider_service(),
             },
@@ -197,6 +232,8 @@ mod tests {
         assert_eq!(cfg.scaling.idle_timeout_secs, 300);
         assert_eq!(cfg.scaling.wake_timeout().as_secs(), 60);
         assert_eq!(cfg.proxy.request_timeout().as_secs(), 30);
+        assert!(!cfg.registry.durable_enabled);
+        assert_eq!(cfg.registry.etcd_endpoints, "http://localhost:2379");
         assert_eq!(cfg.routing.file_provider_service, "s2z-nscale@file");
     }
 }

--- a/crates/nscale-core/src/traits.rs
+++ b/crates/nscale-core/src/traits.rs
@@ -1,9 +1,11 @@
+use std::pin::Pin;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures_core::Stream;
 
 use crate::error::Result;
-use crate::job::{Endpoint, JobId, ServiceName};
+use crate::job::{Endpoint, JobId, JobRegistration, ServiceName};
 
 /// Abstraction over a job orchestrator (Nomad).
 #[async_trait]
@@ -64,4 +66,38 @@ pub trait ActivityStore: Send + Sync {
 
     /// Remove activity tracking for a job (after scale-down).
     async fn remove_activity(&self, job_id: &JobId) -> Result<()>;
+}
+
+/// Change notification emitted by a durable registration store.
+#[derive(Debug, Clone)]
+pub enum RegistrationEvent {
+    Upsert(JobRegistration),
+    Remove(JobRegistration),
+}
+
+/// Abstraction over a durable registration store.
+#[async_trait]
+pub trait DurableRegistry: Send + Sync {
+    /// Store or update a job registration durably.
+    async fn store_registration(&self, reg: &JobRegistration) -> Result<()>;
+
+    /// Remove a registration from durable storage.
+    async fn remove_registration(&self, job_id: &JobId) -> Result<()>;
+
+    /// Look up a registration by job id.
+    async fn get_by_job_id(&self, job_id: &JobId) -> Result<Option<JobRegistration>>;
+
+    /// Look up a registration by service name.
+    async fn get_by_service_name(
+        &self,
+        service_name: &ServiceName,
+    ) -> Result<Option<JobRegistration>>;
+
+    /// List all current registrations.
+    async fn list_all(&self) -> Result<Vec<JobRegistration>>;
+
+    /// Watch for registration changes.
+    async fn watch_registrations(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = RegistrationEvent> + Send>>>;
 }

--- a/crates/nscale-etcd/Cargo.toml
+++ b/crates/nscale-etcd/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "nscale-core"
+name = "nscale-etcd"
 version = "2.1.0"
 edition = "2024"
 
 [dependencies]
+nscale-core = { path = "../nscale-core" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-thiserror = { workspace = true }
 async-trait = { workspace = true }
-figment = { workspace = true }
-reqwest = { workspace = true }
+etcd-client = "0.18"
 futures-core = "0.3"
+futures-util = "0.3"

--- a/crates/nscale-etcd/src/client.rs
+++ b/crates/nscale-etcd/src/client.rs
@@ -1,7 +1,7 @@
 use std::pin::Pin;
 
 use async_trait::async_trait;
-use etcd_client::{Client, DeleteOptions, GetOptions};
+use etcd_client::{Client, GetOptions, Txn, TxnOp};
 use futures_core::Stream;
 use futures_util::stream;
 use tokio::sync::Mutex;
@@ -52,6 +52,16 @@ impl EtcdClient {
         serde_json::from_slice(bytes).map_err(|e| NscaleError::Store(e.to_string()))
     }
 
+    async fn apply_txn(&self, operations: Vec<TxnOp>) -> Result<()> {
+        let mut client = self.client.lock().await;
+        client
+            .txn(Txn::new().and_then(operations))
+            .await
+            .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+        Ok(())
+    }
+
     async fn get_by_key(&self, key: String) -> Result<Option<JobRegistration>> {
         let mut client = self.client.lock().await;
         let response = client
@@ -79,6 +89,31 @@ impl EtcdClient {
             .map(|kv| Self::decode_registration(kv.value()))
             .collect()
     }
+
+    async fn service_keys_for_job(&self, job_id: &JobId) -> Result<Vec<String>> {
+        if let Some(reg) = self.get_by_job_id(job_id).await? {
+            return Ok(vec![self.service_key(&reg.service_name)]);
+        }
+
+        let mut client = self.client.lock().await;
+        let response = client
+            .get(
+                self.services_prefix(),
+                Some(GetOptions::new().with_prefix()),
+            )
+            .await
+            .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+        let mut keys = Vec::new();
+        for kv in response.kvs() {
+            let reg = Self::decode_registration(kv.value())?;
+            if reg.job_id == *job_id {
+                keys.push(String::from_utf8_lossy(kv.key()).into_owned());
+            }
+        }
+
+        Ok(keys)
+    }
 }
 
 #[async_trait]
@@ -89,62 +124,24 @@ impl DurableRegistry for EtcdClient {
         let job_key = self.job_key(&reg.job_id);
         let service_key = self.service_key(&reg.service_name);
 
-        let mut client = self.client.lock().await;
-        client
-            .put(job_key, encoded.clone(), None)
-            .await
-            .map_err(|e| NscaleError::Store(e.to_string()))?;
-        client
-            .put(service_key, encoded, None)
-            .await
-            .map_err(|e| NscaleError::Store(e.to_string()))?;
-
-        Ok(())
+        self.apply_txn(vec![
+            TxnOp::put(job_key, encoded.clone(), None),
+            TxnOp::put(service_key, encoded, None),
+        ])
+        .await
     }
 
     #[instrument(skip(self), fields(job_id = %job_id))]
     async fn remove_registration(&self, job_id: &JobId) -> Result<()> {
-        let existing = self.get_by_job_id(job_id).await?;
-        let job_key = self.job_key(job_id);
+        let mut operations = self
+            .service_keys_for_job(job_id)
+            .await?
+            .into_iter()
+            .map(|key| TxnOp::delete(key, None))
+            .collect::<Vec<_>>();
+        operations.push(TxnOp::delete(self.job_key(job_id), None));
 
-        let mut client = self.client.lock().await;
-        client
-            .delete(job_key, None)
-            .await
-            .map_err(|e| NscaleError::Store(e.to_string()))?;
-
-        if let Some(reg) = existing {
-            client
-                .delete(self.service_key(&reg.service_name), None)
-                .await
-                .map_err(|e| NscaleError::Store(e.to_string()))?;
-        } else {
-            let response = client
-                .get(
-                    self.services_prefix(),
-                    Some(GetOptions::new().with_prefix()),
-                )
-                .await
-                .map_err(|e| NscaleError::Store(e.to_string()))?;
-
-            let keys_to_delete = response
-                .kvs()
-                .iter()
-                .filter_map(|kv| match Self::decode_registration(kv.value()) {
-                    Ok(reg) if reg.job_id == *job_id => Some(kv.key().to_vec()),
-                    _ => None,
-                })
-                .collect::<Vec<_>>();
-
-            for key in keys_to_delete {
-                client
-                    .delete(key, Some(DeleteOptions::new()))
-                    .await
-                    .map_err(|e| NscaleError::Store(e.to_string()))?;
-            }
-        }
-
-        Ok(())
+        self.apply_txn(operations).await
     }
 
     #[instrument(skip(self), fields(job_id = %job_id))]
@@ -196,8 +193,14 @@ mod tests {
 
     #[test]
     fn normalizes_prefix() {
-        assert_eq!(normalize_prefix("/nscale/registrations/".to_string()), "/nscale/registrations");
-        assert_eq!(normalize_prefix("nscale/registrations".to_string()), "/nscale/registrations");
+        assert_eq!(
+            normalize_prefix("/nscale/registrations/".to_string()),
+            "/nscale/registrations"
+        );
+        assert_eq!(
+            normalize_prefix("nscale/registrations".to_string()),
+            "/nscale/registrations"
+        );
         assert_eq!(normalize_prefix("   ".to_string()), "/nscale/registrations");
     }
 

--- a/crates/nscale-etcd/src/client.rs
+++ b/crates/nscale-etcd/src/client.rs
@@ -91,10 +91,6 @@ impl EtcdClient {
     }
 
     async fn service_keys_for_job(&self, job_id: &JobId) -> Result<Vec<String>> {
-        if let Some(reg) = self.get_by_job_id(job_id).await? {
-            return Ok(vec![self.service_key(&reg.service_name)]);
-        }
-
         let mut client = self.client.lock().await;
         let response = client
             .get(

--- a/crates/nscale-etcd/src/client.rs
+++ b/crates/nscale-etcd/src/client.rs
@@ -1,0 +1,219 @@
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use etcd_client::{Client, DeleteOptions, GetOptions};
+use futures_core::Stream;
+use futures_util::stream;
+use tokio::sync::Mutex;
+use tracing::instrument;
+
+use nscale_core::error::{NscaleError, Result};
+use nscale_core::job::{JobId, JobRegistration, ServiceName};
+use nscale_core::traits::{DurableRegistry, RegistrationEvent};
+
+pub struct EtcdClient {
+    client: Mutex<Client>,
+    key_prefix: String,
+}
+
+impl EtcdClient {
+    pub async fn new(endpoints: Vec<String>, key_prefix: impl Into<String>) -> Result<Self> {
+        let client = Client::connect(endpoints, None)
+            .await
+            .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+        Ok(Self {
+            client: Mutex::new(client),
+            key_prefix: normalize_prefix(key_prefix.into()),
+        })
+    }
+
+    fn jobs_prefix(&self) -> String {
+        format!("{}/jobs/", self.key_prefix)
+    }
+
+    fn services_prefix(&self) -> String {
+        format!("{}/services/", self.key_prefix)
+    }
+
+    fn job_key(&self, job_id: &JobId) -> String {
+        format!("{}{job_id}", self.jobs_prefix())
+    }
+
+    fn service_key(&self, service_name: &ServiceName) -> String {
+        format!("{}{service_name}", self.services_prefix())
+    }
+
+    fn encode_registration(reg: &JobRegistration) -> Result<Vec<u8>> {
+        serde_json::to_vec(reg).map_err(|e| NscaleError::Store(e.to_string()))
+    }
+
+    fn decode_registration(bytes: &[u8]) -> Result<JobRegistration> {
+        serde_json::from_slice(bytes).map_err(|e| NscaleError::Store(e.to_string()))
+    }
+
+    async fn get_by_key(&self, key: String) -> Result<Option<JobRegistration>> {
+        let mut client = self.client.lock().await;
+        let response = client
+            .get(key, None)
+            .await
+            .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+        response
+            .kvs()
+            .first()
+            .map(|kv| Self::decode_registration(kv.value()))
+            .transpose()
+    }
+
+    async fn list_by_prefix(&self, prefix: String) -> Result<Vec<JobRegistration>> {
+        let mut client = self.client.lock().await;
+        let response = client
+            .get(prefix, Some(GetOptions::new().with_prefix()))
+            .await
+            .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+        response
+            .kvs()
+            .iter()
+            .map(|kv| Self::decode_registration(kv.value()))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl DurableRegistry for EtcdClient {
+    #[instrument(skip(self), fields(job_id = %reg.job_id, service_name = %reg.service_name))]
+    async fn store_registration(&self, reg: &JobRegistration) -> Result<()> {
+        let encoded = Self::encode_registration(reg)?;
+        let job_key = self.job_key(&reg.job_id);
+        let service_key = self.service_key(&reg.service_name);
+
+        let mut client = self.client.lock().await;
+        client
+            .put(job_key, encoded.clone(), None)
+            .await
+            .map_err(|e| NscaleError::Store(e.to_string()))?;
+        client
+            .put(service_key, encoded, None)
+            .await
+            .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+        Ok(())
+    }
+
+    #[instrument(skip(self), fields(job_id = %job_id))]
+    async fn remove_registration(&self, job_id: &JobId) -> Result<()> {
+        let existing = self.get_by_job_id(job_id).await?;
+        let job_key = self.job_key(job_id);
+
+        let mut client = self.client.lock().await;
+        client
+            .delete(job_key, None)
+            .await
+            .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+        if let Some(reg) = existing {
+            client
+                .delete(self.service_key(&reg.service_name), None)
+                .await
+                .map_err(|e| NscaleError::Store(e.to_string()))?;
+        } else {
+            let response = client
+                .get(
+                    self.services_prefix(),
+                    Some(GetOptions::new().with_prefix()),
+                )
+                .await
+                .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+            let keys_to_delete = response
+                .kvs()
+                .iter()
+                .filter_map(|kv| match Self::decode_registration(kv.value()) {
+                    Ok(reg) if reg.job_id == *job_id => Some(kv.key().to_vec()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+
+            for key in keys_to_delete {
+                client
+                    .delete(key, Some(DeleteOptions::new()))
+                    .await
+                    .map_err(|e| NscaleError::Store(e.to_string()))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[instrument(skip(self), fields(job_id = %job_id))]
+    async fn get_by_job_id(&self, job_id: &JobId) -> Result<Option<JobRegistration>> {
+        self.get_by_key(self.job_key(job_id)).await
+    }
+
+    #[instrument(skip(self), fields(service_name = %service_name))]
+    async fn get_by_service_name(
+        &self,
+        service_name: &ServiceName,
+    ) -> Result<Option<JobRegistration>> {
+        self.get_by_key(self.service_key(service_name)).await
+    }
+
+    #[instrument(skip(self))]
+    async fn list_all(&self) -> Result<Vec<JobRegistration>> {
+        let service_regs = self.list_by_prefix(self.services_prefix()).await?;
+        if !service_regs.is_empty() {
+            return Ok(service_regs);
+        }
+
+        self.list_by_prefix(self.jobs_prefix()).await
+    }
+
+    async fn watch_registrations(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = RegistrationEvent> + Send>>> {
+        Ok(Box::pin(stream::empty()))
+    }
+}
+
+fn normalize_prefix(prefix: String) -> String {
+    let trimmed = prefix.trim();
+    let trimmed = trimmed.trim_end_matches('/');
+
+    if trimmed.is_empty() {
+        "/nscale/registrations".to_string()
+    } else if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_prefix() {
+        assert_eq!(normalize_prefix("/nscale/registrations/".to_string()), "/nscale/registrations");
+        assert_eq!(normalize_prefix("nscale/registrations".to_string()), "/nscale/registrations");
+        assert_eq!(normalize_prefix("   ".to_string()), "/nscale/registrations");
+    }
+
+    #[test]
+    fn registration_round_trip_codec() {
+        let reg = JobRegistration {
+            job_id: JobId("job-a".to_string()),
+            service_name: ServiceName("svc-a".to_string()),
+            nomad_group: "main".to_string(),
+        };
+
+        let encoded = EtcdClient::encode_registration(&reg).expect("encode registration");
+        let decoded = EtcdClient::decode_registration(&encoded).expect("decode registration");
+
+        assert_eq!(decoded.job_id.0, "job-a");
+        assert_eq!(decoded.service_name.0, "svc-a");
+        assert_eq!(decoded.nomad_group, "main");
+    }
+}

--- a/crates/nscale-etcd/src/lib.rs
+++ b/crates/nscale-etcd/src/lib.rs
@@ -1,0 +1,3 @@
+mod client;
+
+pub use client::EtcdClient;

--- a/crates/nscale-store/src/registry.rs
+++ b/crates/nscale-store/src/registry.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use fred::prelude::*;
-use tracing::{debug, instrument};
+use tracing::{debug, error, instrument};
 
 use nscale_core::error::{NscaleError, Result};
 use nscale_core::job::{JobId, JobRegistration, ServiceName};
@@ -107,10 +107,25 @@ impl JobRegistry {
 
     #[instrument(skip(self), fields(job_id = %job_id))]
     pub async fn deregister(&self, job_id: &JobId) -> Result<()> {
-        self.remove_cached_registration(job_id).await?;
+        let existing = self.get(job_id).await?;
 
         if let Some(durable) = &self.durable {
             durable.remove_registration(job_id).await?;
+
+            if let Err(err) = self.remove_cached_registration(job_id).await {
+                if let Some(reg) = existing.as_ref() && let Err(restore_err) = durable.store_registration(reg).await {
+                        error!(
+                            job_id = %job_id,
+                            error = %restore_err,
+                            "failed to restore durable registration after Redis cache eviction error"
+                        );
+                    }
+                
+
+                return Err(err);
+            }
+        } else {
+            self.remove_cached_registration(job_id).await?;
         }
         debug!("deregistered job");
         Ok(())

--- a/crates/nscale-store/src/registry.rs
+++ b/crates/nscale-store/src/registry.rs
@@ -54,6 +54,33 @@ impl JobRegistry {
         Ok(())
     }
 
+    async fn remove_cached_registration(&self, job_id: &JobId) -> Result<()> {
+        let service_entries: std::collections::HashMap<String, String> = self
+            .client
+            .hgetall(REGISTRY_BY_SERVICE_KEY)
+            .await
+            .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+        for (service_name, value) in service_entries {
+            let reg: JobRegistration = serde_json::from_str(&value)?;
+            if reg.job_id == *job_id {
+                let _: i64 = self
+                    .client
+                    .hdel(REGISTRY_BY_SERVICE_KEY, service_name.as_str())
+                    .await
+                    .map_err(|e| NscaleError::Store(e.to_string()))?;
+            }
+        }
+
+        let _: i64 = self
+            .client
+            .hdel(REGISTRY_BY_JOB_KEY, job_id.0.as_str())
+            .await
+            .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+        Ok(())
+    }
+
     pub async fn sync_from_durable(&self) -> Result<usize> {
         let Some(durable) = &self.durable else {
             return Ok(0);
@@ -80,32 +107,11 @@ impl JobRegistry {
 
     #[instrument(skip(self), fields(job_id = %job_id))]
     pub async fn deregister(&self, job_id: &JobId) -> Result<()> {
+        self.remove_cached_registration(job_id).await?;
+
         if let Some(durable) = &self.durable {
             durable.remove_registration(job_id).await?;
         }
-
-        let service_entries: std::collections::HashMap<String, String> = self
-            .client
-            .hgetall(REGISTRY_BY_SERVICE_KEY)
-            .await
-            .map_err(|e| NscaleError::Store(e.to_string()))?;
-
-        for (service_name, value) in service_entries {
-            let reg: JobRegistration = serde_json::from_str(&value)?;
-            if reg.job_id == *job_id {
-                let _: i64 = self
-                    .client
-                    .hdel(REGISTRY_BY_SERVICE_KEY, service_name.as_str())
-                    .await
-                    .map_err(|e| NscaleError::Store(e.to_string()))?;
-            }
-        }
-
-        let _: i64 = self
-            .client
-            .hdel(REGISTRY_BY_JOB_KEY, job_id.0.as_str())
-            .await
-            .map_err(|e| NscaleError::Store(e.to_string()))?;
         debug!("deregistered job");
         Ok(())
     }

--- a/crates/nscale-store/src/registry.rs
+++ b/crates/nscale-store/src/registry.rs
@@ -1,8 +1,11 @@
+use std::sync::Arc;
+
 use fred::prelude::*;
 use tracing::{debug, instrument};
 
 use nscale_core::error::{NscaleError, Result};
-use nscale_core::job::{JobId, JobRegistration};
+use nscale_core::job::{JobId, JobRegistration, ServiceName};
+use nscale_core::traits::DurableRegistry;
 
 const REGISTRY_BY_JOB_KEY: &str = "nscale:jobs";
 const REGISTRY_BY_SERVICE_KEY: &str = "nscale:jobs:services";
@@ -10,16 +13,30 @@ const REGISTRY_BY_SERVICE_KEY: &str = "nscale:jobs:services";
 /// Job registry backed by a Redis hash.
 pub struct JobRegistry {
     client: Client,
+    durable: Option<Arc<dyn DurableRegistry>>,
 }
 
 impl JobRegistry {
     pub fn new(client: Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            durable: None,
+        }
     }
 
-    #[instrument(skip(self), fields(job_id = %reg.job_id))]
-    pub async fn register(&self, reg: &JobRegistration) -> Result<()> {
-        let value = serde_json::to_string(reg).map_err(|e| NscaleError::Store(e.to_string()))?;
+    pub fn with_durable(client: Client, durable: Arc<dyn DurableRegistry>) -> Self {
+        Self {
+            client,
+            durable: Some(durable),
+        }
+    }
+
+    fn encode_registration(reg: &JobRegistration) -> Result<String> {
+        serde_json::to_string(reg).map_err(|e| NscaleError::Store(e.to_string()))
+    }
+
+    async fn cache_registration(&self, reg: &JobRegistration) -> Result<()> {
+        let value = Self::encode_registration(reg)?;
         let _: () = self
             .client
             .hset(REGISTRY_BY_JOB_KEY, (reg.job_id.0.as_str(), value.as_str()))
@@ -33,12 +50,40 @@ impl JobRegistry {
             )
             .await
             .map_err(|e| NscaleError::Store(e.to_string()))?;
+
+        Ok(())
+    }
+
+    pub async fn sync_from_durable(&self) -> Result<usize> {
+        let Some(durable) = &self.durable else {
+            return Ok(0);
+        };
+
+        let regs = durable.list_all().await?;
+        for reg in &regs {
+            self.cache_registration(reg).await?;
+        }
+
+        Ok(regs.len())
+    }
+
+    #[instrument(skip(self), fields(job_id = %reg.job_id))]
+    pub async fn register(&self, reg: &JobRegistration) -> Result<()> {
+        if let Some(durable) = &self.durable {
+            durable.store_registration(reg).await?;
+        }
+
+        self.cache_registration(reg).await?;
         debug!("registered job");
         Ok(())
     }
 
     #[instrument(skip(self), fields(job_id = %job_id))]
     pub async fn deregister(&self, job_id: &JobId) -> Result<()> {
+        if let Some(durable) = &self.durable {
+            durable.remove_registration(job_id).await?;
+        }
+
         let service_entries: std::collections::HashMap<String, String> = self
             .client
             .hgetall(REGISTRY_BY_SERVICE_KEY)
@@ -87,10 +132,33 @@ impl JobRegistry {
             .await?
         {
             Some(reg) => Ok(Some(reg)),
-            None => {
-                self.get_from_hash(REGISTRY_BY_SERVICE_KEY, lookup.0.as_str())
-                    .await
-            }
+            None => match self
+                .get_from_hash(REGISTRY_BY_SERVICE_KEY, lookup.0.as_str())
+                .await?
+            {
+                Some(reg) => Ok(Some(reg)),
+                None => {
+                    let Some(durable) = &self.durable else {
+                        return Ok(None);
+                    };
+
+                    let durable_hit = match durable.get_by_job_id(lookup).await? {
+                        Some(reg) => Some(reg),
+                        None => {
+                            durable
+                                .get_by_service_name(&ServiceName(lookup.0.clone()))
+                                .await?
+                        }
+                    };
+
+                    if let Some(reg) = durable_hit {
+                        self.cache_registration(&reg).await?;
+                        Ok(Some(reg))
+                    } else {
+                        Ok(None)
+                    }
+                }
+            },
         }
     }
 
@@ -109,6 +177,18 @@ impl JobRegistry {
         } else {
             entries
         };
+
+        if entries.is_empty() {
+            let Some(durable) = &self.durable else {
+                return Ok(Vec::new());
+            };
+
+            let regs = durable.list_all().await?;
+            for reg in &regs {
+                self.cache_registration(reg).await?;
+            }
+            return Ok(regs);
+        }
 
         let mut regs = Vec::with_capacity(entries.len());
         for (_key, value) in entries {

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,6 @@ The goal of these documents is to explain how the system behaves, which settings
 
 - [`job-submission.md`](./job-submission.md) — how to submit Nomad HCL through `/admin/jobs`, what tags nscale injects, and how auto-registration works.
 - [`performance-configuration.md`](./performance-configuration.md) — baseline configuration guidance for production-style and mixed-fleet deployments, with explanations of the most important settings and how they interact.
+- [`durable-registry.md`](./durable-registry.md) — etcd-backed registration storage with Redis cache/read-through behavior and multi-replica recovery notes.
 
 Additional guides for deployment, troubleshooting, and observability are in progress.

--- a/docs/durable-registry.md
+++ b/docs/durable-registry.md
@@ -1,0 +1,111 @@
+# Durable registry mode
+
+This guide explains how `nscale` stores job registrations when durable registry mode is enabled.
+
+In this mode:
+
+1. etcd is the source of truth for `JobRegistration` data
+2. Redis remains the fast cache used by the proxy, scaler, and event processor
+3. cache misses are repaired by reading from etcd and writing the result back to Redis
+4. repeated writes are idempotent, so multiple replicas can safely register the same job
+
+This is the recommended mode when you expect to run more than one `nscale` replica or when you want
+registry data to survive Redis cache loss.
+
+## Data model
+
+Each registration is stored under two durable keys in etcd:
+
+- job lookup: `/nscale/registrations/jobs/<job_id>`
+- service lookup: `/nscale/registrations/services/<service_name>`
+
+The value in each key is the JSON-serialized `JobRegistration`:
+
+```json
+{
+  "job_id": "echo-submit-job",
+  "service_name": "echo-s2z",
+  "nomad_group": "main"
+}
+```
+
+Redis keeps the same two lookup shapes in the hashes used by the current registry cache:
+
+- `nscale:jobs`
+- `nscale:jobs:services`
+
+## Read path
+
+`JobRegistry::get()` uses cache-aside behavior:
+
+1. look in Redis by job ID
+2. if that misses, look in Redis by service name
+3. if Redis misses and durable mode is enabled, query etcd
+4. repopulate Redis from the durable result
+5. return the registration
+
+This keeps the request path fast while still allowing recovery from Redis loss.
+
+## Write path
+
+When durable mode is enabled, registration writes are durable-first:
+
+1. write to etcd
+2. write to Redis cache
+
+If etcd fails, the write fails. That prevents Redis from being populated with data that is not durable.
+
+## Recovery behavior
+
+On startup, nscale can hydrate Redis from etcd before handling traffic.
+
+In multi-replica deployments, each replica can repair its local Redis cache independently. That
+means a cache loss on one replica does not require manual per-job re-registration.
+
+This is the behavior covered by:
+
+- `integration/test-durable.sh`
+- `integration/test-durable-multi-replica.sh`
+
+## Configuration
+
+Enable durable registry mode with:
+
+```toml
+[default.registry]
+durable_enabled = true
+etcd_endpoints = "http://etcd:2379"
+etcd_key_prefix = "/nscale/registrations"
+etcd_watch_backoff_secs = 5
+```
+
+Equivalent environment variables:
+
+- `NSCALE_REGISTRY__DURABLE_ENABLED=true`
+- `NSCALE_REGISTRY__ETCD_ENDPOINTS=http://etcd:2379`
+- `NSCALE_REGISTRY__ETCD_KEY_PREFIX=/nscale/registrations`
+- `NSCALE_REGISTRY__ETCD_WATCH_BACKOFF_SECS=5`
+
+## When to use it
+
+Use durable registry mode when:
+
+- you run more than one `nscale` replica
+- you want registry data to survive Redis cache loss
+- you want read-through cache repair without manual `/admin/registry` calls
+
+Keep it disabled when:
+
+- you only want the default Redis-only behavior
+- you are experimenting locally and do not want an etcd dependency
+
+## Test commands
+
+```bash
+cd integration
+./test-durable.sh
+./test-durable-multi-replica.sh
+```
+
+The multi-replica test proves that replica B can read through to etcd after replica A writes the
+registration and Redis is cleared.

--- a/docs/durable-registry.md
+++ b/docs/durable-registry.md
@@ -76,6 +76,7 @@ Enable durable registry mode with:
 durable_enabled = true
 etcd_endpoints = "http://etcd:2379"
 etcd_key_prefix = "/nscale/registrations"
+# Reserved for future watch/reconcile wiring; currently unused.
 etcd_watch_backoff_secs = 5
 ```
 
@@ -84,7 +85,7 @@ Equivalent environment variables:
 - `NSCALE_REGISTRY__DURABLE_ENABLED=true`
 - `NSCALE_REGISTRY__ETCD_ENDPOINTS=http://etcd:2379`
 - `NSCALE_REGISTRY__ETCD_KEY_PREFIX=/nscale/registrations`
-- `NSCALE_REGISTRY__ETCD_WATCH_BACKOFF_SECS=5`
+- `NSCALE_REGISTRY__ETCD_WATCH_BACKOFF_SECS=5` (reserved for future watch/reconcile wiring; currently unused)
 
 ## When to use it
 

--- a/docs/job-submission.md
+++ b/docs/job-submission.md
@@ -7,7 +7,7 @@ The `/admin/jobs` endpoint is the preferred path when you want `nscale` to own t
 1. parse Nomad HCL with optional variables
 2. inject the Traefik router service override required for warm-path routing through `nscale`
 3. submit the mutated job to Nomad
-4. auto-register every managed service in Redis
+4. auto-register every managed service in Redis, and in etcd when durable registry mode is enabled
 5. seed activity so the scaler can safely detect future idleness
 
 ## Why use `/admin/jobs`
@@ -20,6 +20,12 @@ Without it, operators have to do two things correctly every time:
 - call `/admin/registry` or `/admin/registry/sync` so `nscale` can wake and scale the job later
 
 With `/admin/jobs`, `nscale` does both automatically.
+
+When durable registry mode is enabled, that automatic registration becomes durable-first:
+
+- write the registration to etcd
+- refresh the Redis cache from the durable result
+- repopulate Redis on cache miss if a replica needs to read through later
 
 ## Request format
 
@@ -128,6 +134,9 @@ That registration is used by:
 This is especially important when `service_name` differs from `job_id`.
 The updated registry path supports both lookup modes.
 
+If durable registry mode is enabled, the same `JobRegistration` is also persisted in etcd so
+another replica can recover the cache later without manual per-job re-registration.
+
 ## Response shape
 
 Successful responses return the submitted Nomad evaluation data plus the services that were managed:
@@ -195,6 +204,8 @@ The repository now covers this flow in both environments:
 - `integration/test.sh`
 - `integration/test-acl.sh`
 - `nscale-kubernetes/test-hybrid.sh`
+- `integration/test-durable.sh`
+- `integration/test-durable-multi-replica.sh`
 
 The main Docker integration test verifies that `/admin/jobs`:
 
@@ -203,3 +214,9 @@ The main Docker integration test verifies that `/admin/jobs`:
 - auto-registers the service
 - works when `service_name != job_id`
 - still supports wake-on-request and scale-to-zero over both HTTP and HTTPS
+
+The durable integration tests verify that:
+
+- registrations survive Redis cache loss when etcd is available
+- a second nscale replica can read through to etcd and repopulate Redis
+- service lookup still works when `service_name != job_id`

--- a/docs/performance-configuration.md
+++ b/docs/performance-configuration.md
@@ -307,6 +307,23 @@ The following settings are accepted by the configuration loader but do not yet a
 
 Do not assume changing them will affect performance until a future release wires them into the active code path.
 
+## Durable registry mode
+
+If you enable the etcd-backed durable registry, treat it as a correctness and resilience feature,
+not a latency optimization.
+
+Key points:
+
+- Redis remains the hot cache for request-path lookups and scale-down coordination.
+- etcd stores the durable registration source of truth.
+- a Redis cache miss may incur a slightly slower first lookup because `nscale` reads through to etcd
+  and then repopulates Redis.
+- multi-replica deployments should keep durable registry mode enabled so each replica can recover
+  its cache from the same source of truth.
+
+The durable registry settings are configured under `[default.registry]` and are described in more
+detail in [`durable-registry.md`](./durable-registry.md).
+
 ## Suggested environment variables
 
 ```bash

--- a/docs/performance-configuration.md
+++ b/docs/performance-configuration.md
@@ -304,6 +304,7 @@ The following settings are accepted by the configuration loader but do not yet a
 
 - `scaling.min_scale_down_age_secs`
 - `proxy.request_buffer_size`
+- `registry.etcd_watch_backoff_secs`
 
 Do not assume changing them will affect performance until a future release wires them into the active code path.
 

--- a/integration/docker-compose.durable.yml
+++ b/integration/docker-compose.durable.yml
@@ -27,3 +27,30 @@ services:
     depends_on:
       etcd:
         condition: service_healthy
+
+  nscale-2:
+    image: integration-nscale:latest
+    networks: [nscale-net]
+    ports:
+      - "18080:8080"
+      - "19090:9090"
+    volumes:
+      - ./config/:/app/config/:ro
+    environment:
+      RUST_LOG: info,nscale=debug
+      NSCALE_REGISTRY__DURABLE_ENABLED: "true"
+      NSCALE_REGISTRY__ETCD_ENDPOINTS: "http://etcd:2379"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9090/healthz"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+    depends_on:
+      redis:
+        condition: service_healthy
+      consul:
+        condition: service_healthy
+      nomad:
+        condition: service_healthy
+      etcd:
+        condition: service_healthy

--- a/integration/docker-compose.durable.yml
+++ b/integration/docker-compose.durable.yml
@@ -1,0 +1,29 @@
+services:
+  etcd:
+    image: quay.io/coreos/etcd:v3.5.14
+    networks: [nscale-net]
+    environment:
+      ETCDCTL_API: "3"
+    command:
+      - /usr/local/bin/etcd
+      - --name=etcd-1
+      - --data-dir=/etcd-data
+      - --advertise-client-urls=http://etcd:2379
+      - --listen-client-urls=http://0.0.0.0:2379
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --initial-advertise-peer-urls=http://etcd:2380
+      - --initial-cluster=etcd-1=http://etcd:2380
+      - --initial-cluster-state=new
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/etcdctl", "--endpoints=http://127.0.0.1:2379", "endpoint", "health"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+
+  nscale:
+    environment:
+      NSCALE_REGISTRY__DURABLE_ENABLED: "true"
+      NSCALE_REGISTRY__ETCD_ENDPOINTS: "http://etcd:2379"
+    depends_on:
+      etcd:
+        condition: service_healthy

--- a/integration/test-durable-multi-replica.sh
+++ b/integration/test-durable-multi-replica.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Integration test for nscale durable registry mode with two nscale replicas.
+#
+# Scenario:
+#   1. Start infrastructure with etcd durable registry and two nscale replicas
+#   2. Submit a Nomad job through replica A (/admin/jobs on :9090)
+#   3. Verify registrations exist in Redis and etcd
+#   4. Delete shared Redis registry hashes
+#   5. Send request directly to replica B proxy (:18080) and verify it reloads from etcd
+#   6. Scale the job to zero, purge Redis again, and verify replica B can wake it via etcd fallback
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_BASE="$SCRIPT_DIR/docker-compose.yml"
+COMPOSE_DURABLE="$SCRIPT_DIR/docker-compose.durable.yml"
+JOB_FILE="$SCRIPT_DIR/jobs/echo-submit.nomad"
+TRAEFIK_CERT_SCRIPT="$SCRIPT_DIR/traefik/certs/generate.sh"
+COMPOSE_ARGS=(-f "$COMPOSE_BASE" -f "$COMPOSE_DURABLE")
+
+NOMAD_ADDR="http://localhost:4646"
+NSCALE_ADMIN_A="http://localhost:9090"
+NSCALE_PROXY_B="http://localhost:18080"
+ETCD_PREFIX="${ETCD_PREFIX:-/nscale/registrations}"
+
+JOB_ID="echo-submit-job"
+SERVICE_NAME="${SERVICE_NAME:-echo-s2z}"
+SERVICE_GROUP="${SERVICE_GROUP:-main}"
+ROUTER_HOST="${ROUTER_HOST:-${SERVICE_NAME}.localhost}"
+HOST_HEADER="${HOST_HEADER:-${ROUTER_HOST}}"
+ETCD_JOB_KEY="${ETCD_PREFIX}/jobs/${JOB_ID}"
+ETCD_SERVICE_KEY="${ETCD_PREFIX}/services/${SERVICE_NAME}"
+
+INFRA_TIMEOUT=150
+WAKE_TIMEOUT=60
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}✓ $1${NC}"; }
+fail() { echo -e "${RED}✗ $1${NC}"; }
+info() { echo -e "${YELLOW}→ $1${NC}"; }
+
+dc() {
+    docker compose "${COMPOSE_ARGS[@]}" "$@"
+}
+
+request_replica_b() {
+    local max_time="${1:-30}"
+    curl -s -w "\n%{http_code}" -H "Host: $HOST_HEADER" "$NSCALE_PROXY_B/" --max-time "$max_time"
+}
+
+build_submit_payload() {
+    local variables
+    variables=$(cat <<EOF
+service_name = "${SERVICE_NAME}"
+host_name = "${ROUTER_HOST}"
+EOF
+)
+
+    jq -n --rawfile hcl "$JOB_FILE" --arg variables "$variables" '{hcl: $hcl, variables: $variables}'
+}
+
+assert_redis_registration_present() {
+    local job_json service_json
+    job_json=$(dc exec -T redis redis-cli --raw HGET nscale:jobs "$JOB_ID" | tr -d '\r')
+    service_json=$(dc exec -T redis redis-cli --raw HGET nscale:jobs:services "$SERVICE_NAME" | tr -d '\r')
+
+    if [[ -z "$job_json" || -z "$service_json" ]]; then
+        fail "Expected Redis registry entries for job and service"
+        exit 1
+    fi
+
+    if ! echo "$job_json" | jq -e --arg job_id "$JOB_ID" --arg service_name "$SERVICE_NAME" --arg group "$SERVICE_GROUP" '.job_id == $job_id and .service_name == $service_name and .nomad_group == $group' >/dev/null; then
+        fail "Redis job registration payload is unexpected"
+        echo "$job_json"
+        exit 1
+    fi
+
+    if ! echo "$service_json" | jq -e --arg job_id "$JOB_ID" --arg service_name "$SERVICE_NAME" --arg group "$SERVICE_GROUP" '.job_id == $job_id and .service_name == $service_name and .nomad_group == $group' >/dev/null; then
+        fail "Redis service registration payload is unexpected"
+        echo "$service_json"
+        exit 1
+    fi
+}
+
+assert_etcd_registration_present() {
+    local job_json service_json
+    job_json=$(dc exec -T etcd /usr/local/bin/etcdctl --endpoints=http://127.0.0.1:2379 get "$ETCD_JOB_KEY" --print-value-only | tr -d '\r')
+    service_json=$(dc exec -T etcd /usr/local/bin/etcdctl --endpoints=http://127.0.0.1:2379 get "$ETCD_SERVICE_KEY" --print-value-only | tr -d '\r')
+
+    if [[ -z "$job_json" || -z "$service_json" ]]; then
+        fail "Expected etcd registration entries for job and service"
+        exit 1
+    fi
+}
+
+clear_redis_registry_cache() {
+    dc exec -T redis redis-cli DEL nscale:jobs nscale:jobs:services >/dev/null
+}
+
+assert_redis_registry_empty() {
+    local job_count service_count
+    job_count=$(dc exec -T redis redis-cli HLEN nscale:jobs | tr -d '\r')
+    service_count=$(dc exec -T redis redis-cli HLEN nscale:jobs:services | tr -d '\r')
+
+    if [[ "$job_count" != "0" || "$service_count" != "0" ]]; then
+        fail "Expected Redis registry hashes to be empty after purge"
+        exit 1
+    fi
+}
+
+wait_for_job_running() {
+    local elapsed=0
+    while true; do
+        if [ "$elapsed" -ge "$WAKE_TIMEOUT" ]; then
+            fail "Job did not reach running state within ${WAKE_TIMEOUT}s"
+            curl -s "$NOMAD_ADDR/v1/job/${JOB_ID}/allocations" | jq .
+            exit 1
+        fi
+
+        local status alloc_status
+        status=$(curl -s "$NOMAD_ADDR/v1/job/${JOB_ID}" | jq -r '.Status // "unknown"' 2>/dev/null || echo "unknown")
+        alloc_status=$(curl -s "$NOMAD_ADDR/v1/job/${JOB_ID}/allocations" | jq -r '.[0].ClientStatus // "pending"' 2>/dev/null || echo "pending")
+        if [ "$status" = "running" ] && [ "$alloc_status" = "running" ]; then
+            return 0
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+wait_for_deployment_complete() {
+    local elapsed=0
+    while true; do
+        if [ "$elapsed" -ge 60 ]; then
+            fail "Deployment did not complete within 60s"
+            exit 1
+        fi
+
+        local deployment_status
+        deployment_status=$(curl -s "$NOMAD_ADDR/v1/job/${JOB_ID}/deployments" | jq -r '.[0].Status // "null"')
+        if [ "$deployment_status" = "successful" ] || [ "$deployment_status" = "null" ]; then
+            return 0
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+wait_for_job_zero() {
+    local elapsed=0
+    while true; do
+        if [ "$elapsed" -ge 30 ]; then
+            fail "Job did not scale to zero within 30s"
+            exit 1
+        fi
+
+        local running_allocs
+        running_allocs=$(curl -s "$NOMAD_ADDR/v1/job/${JOB_ID}/allocations" | jq '[.[] | select(.ClientStatus == "running")] | length')
+        if [ "$running_allocs" -eq 0 ]; then
+            return 0
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+cleanup() {
+    info "Cleaning up multi-replica durable integration stack..."
+    cd "$SCRIPT_DIR"
+    dc down -v --remove-orphans 2>/dev/null || true
+    docker network rm nscale-net 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+info "Checking prerequisites..."
+for cmd in docker curl jq openssl; do
+    if ! command -v "$cmd" &>/dev/null; then
+        fail "Required command '$cmd' not found"
+        exit 1
+    fi
+done
+pass "Prerequisites OK"
+
+info "Ensuring local Traefik TLS certificates exist..."
+bash "$TRAEFIK_CERT_SCRIPT"
+pass "Traefik TLS certificates ready"
+
+info "Starting multi-replica durable integration stack..."
+cd "$SCRIPT_DIR"
+dc up -d --build
+
+info "Waiting for both nscale replicas and dependencies to be healthy..."
+elapsed=0
+while true; do
+    if [ "$elapsed" -ge "$INFRA_TIMEOUT" ]; then
+        fail "Multi-replica durable stack did not start within ${INFRA_TIMEOUT}s"
+        dc logs
+        exit 1
+    fi
+
+    redis_ok=$(dc ps --format json | jq -r 'select(.Service=="redis") | .Health' 2>/dev/null || echo "unknown")
+    consul_ok=$(dc ps --format json | jq -r 'select(.Service=="consul") | .Health' 2>/dev/null || echo "unknown")
+    nomad_ok=$(dc ps --format json | jq -r 'select(.Service=="nomad") | .Health' 2>/dev/null || echo "unknown")
+    etcd_ok=$(dc ps --format json | jq -r 'select(.Service=="etcd") | .Health' 2>/dev/null || echo "unknown")
+    nscale_a_ok=$(dc ps --format json | jq -r 'select(.Service=="nscale") | .Health' 2>/dev/null || echo "unknown")
+    nscale_b_ok=$(dc ps --format json | jq -r 'select(.Service=="nscale-2") | .Health' 2>/dev/null || echo "unknown")
+    traefik_ok=$(dc ps --format json | jq -r 'select(.Service=="traefik") | .Health' 2>/dev/null || echo "unknown")
+
+    if [[ "$redis_ok" == "healthy" && "$consul_ok" == "healthy" && "$nomad_ok" == "healthy" && "$etcd_ok" == "healthy" && "$nscale_a_ok" == "healthy" && "$nscale_b_ok" == "healthy" && "$traefik_ok" == "healthy" ]]; then
+        break
+    fi
+
+    sleep 3
+    elapsed=$((elapsed + 3))
+    echo "  ... waiting (${elapsed}s) redis=$redis_ok consul=$consul_ok nomad=$nomad_ok etcd=$etcd_ok nscale=$nscale_a_ok nscale-2=$nscale_b_ok traefik=$traefik_ok"
+done
+pass "Both replicas and dependencies are healthy (${elapsed}s)"
+
+info "Submitting variableized echo job through replica A admin API..."
+SUBMIT_PAYLOAD=$(build_submit_payload)
+SUBMIT_RESP=$(curl -sS -w "\n%{http_code}" -X POST "$NSCALE_ADMIN_A/admin/jobs" \
+    -H "Content-Type: application/json" \
+    -d "$SUBMIT_PAYLOAD")
+SUBMIT_CODE=$(echo "$SUBMIT_RESP" | tail -1)
+SUBMIT_BODY=$(echo "$SUBMIT_RESP" | sed '$d')
+if [ "$SUBMIT_CODE" != "201" ]; then
+    fail "Replica A submission failed: HTTP $SUBMIT_CODE"
+    echo "$SUBMIT_BODY"
+    exit 1
+fi
+pass "Replica A submitted and registered the job"
+
+info "Waiting for submitted job to become running..."
+wait_for_job_running
+pass "Job is running"
+
+info "Verifying registration exists in Redis and etcd after replica A submission..."
+assert_redis_registration_present
+assert_etcd_registration_present
+pass "Registration is durable and cached after replica A submission"
+
+info "Purging shared Redis registry hashes before hitting replica B..."
+clear_redis_registry_cache
+assert_redis_registry_empty
+pass "Shared Redis registry cache purged"
+
+info "Requesting the service directly through replica B proxy (should reload from etcd)..."
+RESP=$(request_replica_b 30)
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$HTTP_CODE" != "200" ]; then
+    fail "Replica B warm-path request failed after Redis purge: HTTP $HTTP_CODE — $BODY"
+    dc logs nscale nscale-2 traefik
+    exit 1
+fi
+assert_redis_registration_present
+pass "Replica B reloaded the registry from etcd and repopulated shared Redis"
+
+info "Scaling job to zero before replica B cold-start fallback check..."
+wait_for_deployment_complete
+SCALE_RESP=$(curl -s -w "\n%{http_code}" -X POST "$NOMAD_ADDR/v1/job/${JOB_ID}/scale" \
+    -H "Content-Type: application/json" \
+    -d "{\"Count\":0,\"Target\":{\"Group\":\"${SERVICE_GROUP}\"},\"Message\":\"multi-replica durable integration test: force scale-down\"}")
+SCALE_CODE=$(echo "$SCALE_RESP" | tail -1)
+if [[ ! "$SCALE_CODE" =~ ^2 ]]; then
+    fail "Scale-down before replica B cold-start check failed: HTTP $SCALE_CODE"
+    exit 1
+fi
+wait_for_job_zero
+pass "Job scaled to zero"
+
+info "Purging shared Redis registry hashes again before replica B cold-start request..."
+clear_redis_registry_cache
+assert_redis_registry_empty
+pass "Shared Redis registry cache purged before replica B cold-start request"
+
+info "Requesting the service directly through replica B after scale-to-zero (should wake via etcd fallback)..."
+RESP=$(request_replica_b "$WAKE_TIMEOUT")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$HTTP_CODE" != "200" ]; then
+    fail "Replica B cold-start request failed after Redis purge: HTTP $HTTP_CODE — $BODY"
+    dc logs nscale nscale-2 nomad
+    exit 1
+fi
+assert_redis_registration_present
+pass "Replica B cold-start etcd fallback succeeded and repopulated shared Redis"
+
+echo ""
+echo "========================================"
+echo -e "${GREEN}  Multi-replica durable integration test completed!${NC}"
+echo "========================================"
+echo ""
+echo "Verified:"
+echo "  1. replica A writes registrations durably to etcd and caches them in Redis"
+echo "  2. replica B can serve requests after shared Redis registry loss by falling back to etcd"
+echo "  3. replica B can wake a scaled-to-zero service after shared Redis registry loss"
+echo "  4. shared Redis registry cache is repopulated after replica B fallback"
+echo "  5. service_name (${SERVICE_NAME}) lookup still works when job_id is ${JOB_ID}"
+echo ""

--- a/integration/test-durable.sh
+++ b/integration/test-durable.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Integration test for nscale durable registry mode (etcd + Redis cache)
+#
+# Scenario:
+#   1. Start infrastructure with etcd enabled for nscale durable registry
+#   2. Submit a Nomad job through /admin/jobs
+#   3. Verify registrations exist in both Redis and etcd
+#   4. Delete Redis registry hashes only
+#   5. Verify a warm-path request succeeds via etcd fallback and repopulates Redis
+#   6. Scale job to zero, delete Redis registry hashes again
+#   7. Verify a cold-start request succeeds via etcd fallback and repopulates Redis
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_BASE="$SCRIPT_DIR/docker-compose.yml"
+COMPOSE_DURABLE="$SCRIPT_DIR/docker-compose.durable.yml"
+JOB_FILE="$SCRIPT_DIR/jobs/echo-submit.nomad"
+TRAEFIK_CERT_SCRIPT="$SCRIPT_DIR/traefik/certs/generate.sh"
+COMPOSE_ARGS=(-f "$COMPOSE_BASE" -f "$COMPOSE_DURABLE")
+
+NOMAD_ADDR="http://localhost:4646"
+CONSUL_ADDR="http://localhost:8500"
+NSCALE_PROXY="http://localhost:80"
+NSCALE_ADMIN="http://localhost:9090"
+HTTPS_RESOLVE_ADDR="${HTTPS_RESOLVE_ADDR:-127.0.0.1}"
+ETCD_PREFIX="${ETCD_PREFIX:-/nscale/registrations}"
+
+JOB_ID="echo-submit-job"
+SERVICE_NAME="${SERVICE_NAME:-echo-s2z}"
+SERVICE_GROUP="${SERVICE_GROUP:-main}"
+ROUTER_HOST="${ROUTER_HOST:-${SERVICE_NAME}.localhost}"
+HOST_HEADER="${HOST_HEADER:-${ROUTER_HOST}}"
+ETCD_JOB_KEY="${ETCD_PREFIX}/jobs/${JOB_ID}"
+ETCD_SERVICE_KEY="${ETCD_PREFIX}/services/${SERVICE_NAME}"
+
+INFRA_TIMEOUT=150
+WAKE_TIMEOUT=60
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}✓ $1${NC}"; }
+fail() { echo -e "${RED}✗ $1${NC}"; }
+info() { echo -e "${YELLOW}→ $1${NC}"; }
+
+dc() {
+    docker compose "${COMPOSE_ARGS[@]}" "$@"
+}
+
+request_https() {
+    local max_time="${1:-30}"
+    curl -k -s -w "\n%{http_code}" \
+        --resolve "${HOST_HEADER}:443:${HTTPS_RESOLVE_ADDR}" \
+        "https://${HOST_HEADER}/" \
+        --max-time "$max_time"
+}
+
+build_submit_payload() {
+    local variables
+    variables=$(cat <<EOF
+service_name = "${SERVICE_NAME}"
+host_name = "${ROUTER_HOST}"
+EOF
+)
+
+    jq -n --rawfile hcl "$JOB_FILE" --arg variables "$variables" '{hcl: $hcl, variables: $variables}'
+}
+
+assert_redis_registration_present() {
+    local job_json service_json
+    job_json=$(dc exec -T redis redis-cli --raw HGET nscale:jobs "$JOB_ID" | tr -d '\r')
+    service_json=$(dc exec -T redis redis-cli --raw HGET nscale:jobs:services "$SERVICE_NAME" | tr -d '\r')
+
+    if [[ -z "$job_json" || -z "$service_json" ]]; then
+        fail "Expected Redis registry entries for job and service"
+        exit 1
+    fi
+
+    if ! echo "$job_json" | jq -e --arg job_id "$JOB_ID" --arg service_name "$SERVICE_NAME" --arg group "$SERVICE_GROUP" '.job_id == $job_id and .service_name == $service_name and .nomad_group == $group' >/dev/null; then
+        fail "Redis job registration payload is unexpected"
+        echo "$job_json"
+        exit 1
+    fi
+
+    if ! echo "$service_json" | jq -e --arg job_id "$JOB_ID" --arg service_name "$SERVICE_NAME" --arg group "$SERVICE_GROUP" '.job_id == $job_id and .service_name == $service_name and .nomad_group == $group' >/dev/null; then
+        fail "Redis service registration payload is unexpected"
+        echo "$service_json"
+        exit 1
+    fi
+}
+
+assert_etcd_registration_present() {
+    local job_json service_json
+    job_json=$(dc exec -T etcd /usr/local/bin/etcdctl --endpoints=http://127.0.0.1:2379 get "$ETCD_JOB_KEY" --print-value-only | tr -d '\r')
+    service_json=$(dc exec -T etcd /usr/local/bin/etcdctl --endpoints=http://127.0.0.1:2379 get "$ETCD_SERVICE_KEY" --print-value-only | tr -d '\r')
+
+    if [[ -z "$job_json" || -z "$service_json" ]]; then
+        fail "Expected etcd registration entries for job and service"
+        exit 1
+    fi
+
+    if ! echo "$job_json" | jq -e --arg job_id "$JOB_ID" --arg service_name "$SERVICE_NAME" --arg group "$SERVICE_GROUP" '.job_id == $job_id and .service_name == $service_name and .nomad_group == $group' >/dev/null; then
+        fail "etcd job registration payload is unexpected"
+        echo "$job_json"
+        exit 1
+    fi
+
+    if ! echo "$service_json" | jq -e --arg job_id "$JOB_ID" --arg service_name "$SERVICE_NAME" --arg group "$SERVICE_GROUP" '.job_id == $job_id and .service_name == $service_name and .nomad_group == $group' >/dev/null; then
+        fail "etcd service registration payload is unexpected"
+        echo "$service_json"
+        exit 1
+    fi
+}
+
+clear_redis_registry_cache() {
+    dc exec -T redis redis-cli DEL nscale:jobs nscale:jobs:services >/dev/null
+}
+
+assert_redis_registry_empty() {
+    local job_count service_count
+    job_count=$(dc exec -T redis redis-cli HLEN nscale:jobs | tr -d '\r')
+    service_count=$(dc exec -T redis redis-cli HLEN nscale:jobs:services | tr -d '\r')
+
+    if [[ "$job_count" != "0" || "$service_count" != "0" ]]; then
+        fail "Expected Redis registry hashes to be empty after purge"
+        exit 1
+    fi
+}
+
+wait_for_job_running() {
+    local elapsed=0
+    while true; do
+        if [ "$elapsed" -ge "$WAKE_TIMEOUT" ]; then
+            fail "Job did not reach running state within ${WAKE_TIMEOUT}s"
+            curl -s "$NOMAD_ADDR/v1/job/${JOB_ID}/allocations" | jq .
+            exit 1
+        fi
+
+        local status alloc_status
+        status=$(curl -s "$NOMAD_ADDR/v1/job/${JOB_ID}" | jq -r '.Status // "unknown"' 2>/dev/null || echo "unknown")
+        alloc_status=$(curl -s "$NOMAD_ADDR/v1/job/${JOB_ID}/allocations" | jq -r '.[0].ClientStatus // "pending"' 2>/dev/null || echo "pending")
+        if [ "$status" = "running" ] && [ "$alloc_status" = "running" ]; then
+            return 0
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+wait_for_deployment_complete() {
+    local elapsed=0
+    while true; do
+        if [ "$elapsed" -ge 60 ]; then
+            fail "Deployment did not complete within 60s"
+            exit 1
+        fi
+
+        local deployment_status
+        deployment_status=$(curl -s "$NOMAD_ADDR/v1/job/${JOB_ID}/deployments" | jq -r '.[0].Status // "null"')
+        if [ "$deployment_status" = "successful" ] || [ "$deployment_status" = "null" ]; then
+            return 0
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+wait_for_job_zero() {
+    local elapsed=0
+    while true; do
+        if [ "$elapsed" -ge 30 ]; then
+            fail "Job did not scale to zero within 30s"
+            exit 1
+        fi
+
+        local running_allocs
+        running_allocs=$(curl -s "$NOMAD_ADDR/v1/job/${JOB_ID}/allocations" | jq '[.[] | select(.ClientStatus == "running")] | length')
+        if [ "$running_allocs" -eq 0 ]; then
+            return 0
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+cleanup() {
+    info "Cleaning up durable integration stack..."
+    cd "$SCRIPT_DIR"
+    dc down -v --remove-orphans 2>/dev/null || true
+    docker network rm nscale-net 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+info "Checking prerequisites..."
+for cmd in docker curl jq openssl; do
+    if ! command -v "$cmd" &>/dev/null; then
+        fail "Required command '$cmd' not found"
+        exit 1
+    fi
+done
+pass "Prerequisites OK"
+
+info "Ensuring local Traefik TLS certificates exist..."
+bash "$TRAEFIK_CERT_SCRIPT"
+pass "Traefik TLS certificates ready"
+
+info "Starting durable integration stack..."
+cd "$SCRIPT_DIR"
+dc up -d --build
+
+info "Waiting for all durable-mode services to be healthy..."
+elapsed=0
+while true; do
+    if [ "$elapsed" -ge "$INFRA_TIMEOUT" ]; then
+        fail "Durable integration stack did not start within ${INFRA_TIMEOUT}s"
+        dc logs
+        exit 1
+    fi
+
+    redis_ok=$(dc ps --format json | jq -r 'select(.Service=="redis") | .Health' 2>/dev/null || echo "unknown")
+    consul_ok=$(dc ps --format json | jq -r 'select(.Service=="consul") | .Health' 2>/dev/null || echo "unknown")
+    nomad_ok=$(dc ps --format json | jq -r 'select(.Service=="nomad") | .Health' 2>/dev/null || echo "unknown")
+    etcd_ok=$(dc ps --format json | jq -r 'select(.Service=="etcd") | .Health' 2>/dev/null || echo "unknown")
+    nscale_ok=$(dc ps --format json | jq -r 'select(.Service=="nscale") | .Health' 2>/dev/null || echo "unknown")
+    traefik_ok=$(dc ps --format json | jq -r 'select(.Service=="traefik") | .Health' 2>/dev/null || echo "unknown")
+
+    if [[ "$redis_ok" == "healthy" && "$consul_ok" == "healthy" && "$nomad_ok" == "healthy" && "$etcd_ok" == "healthy" && "$nscale_ok" == "healthy" && "$traefik_ok" == "healthy" ]]; then
+        break
+    fi
+
+    sleep 3
+    elapsed=$((elapsed + 3))
+    echo "  ... waiting (${elapsed}s) redis=$redis_ok consul=$consul_ok nomad=$nomad_ok etcd=$etcd_ok nscale=$nscale_ok traefik=$traefik_ok"
+done
+pass "All durable-mode services healthy (${elapsed}s)"
+
+info "Submitting variableized echo job through nscale admin API..."
+SUBMIT_PAYLOAD=$(build_submit_payload)
+SUBMIT_RESP=$(curl -sS -w "\n%{http_code}" -X POST "$NSCALE_ADMIN/admin/jobs" \
+    -H "Content-Type: application/json" \
+    -d "$SUBMIT_PAYLOAD")
+SUBMIT_CODE=$(echo "$SUBMIT_RESP" | tail -1)
+SUBMIT_BODY=$(echo "$SUBMIT_RESP" | sed '$d')
+
+if [ "$SUBMIT_CODE" != "201" ]; then
+    fail "nscale durable submission failed: HTTP $SUBMIT_CODE"
+    echo "$SUBMIT_BODY"
+    exit 1
+fi
+pass "Job submitted in durable mode"
+
+info "Waiting for submitted job to become running..."
+wait_for_job_running
+pass "Job is running"
+
+info "Verifying registration was persisted to Redis and etcd..."
+assert_redis_registration_present
+assert_etcd_registration_present
+pass "Both Redis cache and etcd durable store contain the registration"
+
+info "Warming the proxy path once before cache-loss checks..."
+RESP=$(request_https 30)
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$HTTP_CODE" != "200" ]; then
+    fail "Warm-path request failed before cache purge: HTTP $HTTP_CODE — $BODY"
+    dc logs nscale traefik
+    exit 1
+fi
+pass "Warm-path request succeeded before cache purge"
+
+info "Purging Redis registry hashes to simulate cache loss..."
+clear_redis_registry_cache
+assert_redis_registry_empty
+pass "Redis registry cache purged"
+
+info "Making warm-path HTTPS request after Redis purge (should reload from etcd)..."
+RESP=$(request_https 30)
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$HTTP_CODE" != "200" ]; then
+    fail "Warm-path request failed after Redis purge: HTTP $HTTP_CODE — $BODY"
+    dc logs nscale traefik
+    exit 1
+fi
+assert_redis_registration_present
+pass "Warm-path etcd fallback succeeded and Redis cache was repopulated"
+
+info "Scaling job to zero to verify cold-start fallback after Redis loss..."
+wait_for_deployment_complete
+SCALE_RESP=$(curl -s -w "\n%{http_code}" -X POST "$NOMAD_ADDR/v1/job/${JOB_ID}/scale" \
+    -H "Content-Type: application/json" \
+    -d "{\"Count\":0,\"Target\":{\"Group\":\"${SERVICE_GROUP}\"},\"Message\":\"durable integration test: force scale-down\"}")
+SCALE_CODE=$(echo "$SCALE_RESP" | tail -1)
+if [[ ! "$SCALE_CODE" =~ ^2 ]]; then
+    fail "Scale-down before cold-start check failed: HTTP $SCALE_CODE"
+    exit 1
+fi
+wait_for_job_zero
+pass "Job scaled to zero"
+
+info "Purging Redis registry hashes again before cold-start request..."
+clear_redis_registry_cache
+assert_redis_registry_empty
+pass "Redis registry cache purged before cold-start request"
+
+info "Making HTTPS request after Redis purge and scale-to-zero (should wake via etcd fallback)..."
+RESP=$(request_https "$WAKE_TIMEOUT")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$HTTP_CODE" != "200" ]; then
+    fail "Cold-start request failed after Redis purge: HTTP $HTTP_CODE — $BODY"
+    dc logs nscale traefik nomad
+    exit 1
+fi
+assert_redis_registration_present
+pass "Cold-start etcd fallback succeeded and Redis cache was repopulated"
+
+echo ""
+echo "========================================"
+echo -e "${GREEN}  Durable integration test completed!${NC}"
+echo "========================================"
+echo ""
+echo "Verified:"
+echo "  1. nscale starts with etcd durable registry enabled"
+echo "  2. /admin/jobs writes registrations to both etcd and Redis"
+echo "  3. Redis registry cache loss is repaired on warm-path lookup via etcd fallback"
+echo "  4. Redis registry cache loss is repaired on cold-start wake via etcd fallback"
+echo "  5. service_name (${SERVICE_NAME}) lookup still works when job_id is ${JOB_ID}"
+echo ""

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,9 @@ async fn main() {
             .collect::<Vec<_>>();
 
         if endpoints.is_empty() {
-            error!("durable registry enabled but NSCALE_REGISTRY__ETCD_ENDPOINTS is empty");
+            error!(
+                "durable registry enabled but registry.etcd_endpoints (NSCALE_REGISTRY__ETCD_ENDPOINTS) is empty"
+            );
             std::process::exit(1);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use nscale_core::error::NscaleError;
 use nscale_core::inflight::InFlightTracker;
 use nscale_core::job::{JobId, JobRegistration};
 use nscale_core::traits::ActivityStore;
+use nscale_etcd::EtcdClient;
 use nscale_nomad::client::NomadClient;
 use nscale_nomad::events::{EventStreamConfig, start_event_stream};
 use nscale_nomad::job_mutator::inject_nscale_tags;
@@ -110,7 +111,44 @@ async fn main() {
     };
     let redis_client = activity_store.client().clone();
     let activity_store: Arc<dyn ActivityStore> = Arc::new(activity_store);
-    let registry = Arc::new(JobRegistry::new(redis_client));
+
+    let registry = if config.registry.durable_enabled {
+        let endpoints = config
+            .registry
+            .etcd_endpoints
+            .split(',')
+            .map(str::trim)
+            .filter(|endpoint| !endpoint.is_empty())
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+
+        if endpoints.is_empty() {
+            error!("durable registry enabled but NSCALE_REGISTRY__ETCD_ENDPOINTS is empty");
+            std::process::exit(1);
+        }
+
+        let durable_registry = Arc::new(
+            EtcdClient::new(endpoints, config.registry.etcd_key_prefix.clone())
+                .await
+                .unwrap_or_else(|e| {
+                    error!(error = %e, "failed to connect to etcd durable registry");
+                    std::process::exit(1);
+                }),
+        );
+
+        let registry = Arc::new(JobRegistry::with_durable(redis_client, durable_registry));
+        match registry.sync_from_durable().await {
+            Ok(restored) => {
+                info!(restored, "hydrated Redis registry cache from etcd");
+            }
+            Err(e) => {
+                error!(error = %e, "failed to hydrate Redis registry cache from etcd");
+            }
+        }
+        registry
+    } else {
+        Arc::new(JobRegistry::new(redis_client))
+    };
     info!("connected to Redis");
 
     // ── Build subsystems ─────────────────────────────────


### PR DESCRIPTION
Introduce support for an etcd-backed durable registry that allows job registrations to persist beyond Redis cache loss. This implementation includes configuration options for enabling durable registrations, integration tests for functionality, and a Docker setup for multi-replica testing. The changes enhance resilience and correctness in job registration management.